### PR TITLE
Add WebUI X Support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,4 +97,6 @@ dependencies {
         exclude(module = "kotlin-reflect")
     }
     implementation(libs.timber)
+    // Compile only since we only need the types to compile the app
+    compileOnly(libs.webui.x)
 }

--- a/app/src/main/kotlin/dev/sanmer/color/picker/model/ColorCss.kt
+++ b/app/src/main/kotlin/dev/sanmer/color/picker/model/ColorCss.kt
@@ -1,0 +1,79 @@
+package dev.sanmer.color.picker.model
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.graphics.Color
+import java.io.OutputStream
+import kotlin.text.appendLine
+
+data class ColorCss(
+    val light: ColorScheme,
+    val dark: ColorScheme,
+) {
+    private val Color.hexValue get(): String = "#${red.hex}${green.hex}${blue.hex}${alpha.hex}"
+
+    private val Float.hex
+        get(): String {
+            return (this * 255).toInt().coerceIn(0, 255).toString(16).padStart(2, '0')
+        }
+
+    private fun StringBuilder.color(name: String, color: Color, end: String = ",\n") {
+        append("\t$name: ${color.hexValue}")
+        append(end)
+    }
+
+    private fun colorScheme(name: String = "root", colorScheme: ColorScheme) = buildString {
+        append(":$name {\n")
+        color("primary", colorScheme.primary)
+        color("onPrimary", colorScheme.onPrimary)
+        color("primaryContainer", colorScheme.primaryContainer)
+        color("onPrimaryContainer", colorScheme.onPrimaryContainer)
+        color("inversePrimary", colorScheme.inversePrimary)
+        color("secondary", colorScheme.secondary)
+        color("onSecondary", colorScheme.onSecondary)
+        color("secondaryContainer", colorScheme.secondaryContainer)
+        color("onSecondaryContainer", colorScheme.onSecondaryContainer)
+        color("tertiary", colorScheme.tertiary)
+        color("onTertiary", colorScheme.onTertiary)
+        color("tertiaryContainer", colorScheme.tertiaryContainer)
+        color("onTertiaryContainer", colorScheme.onTertiaryContainer)
+        color("background", colorScheme.background)
+        color("onBackground", colorScheme.onBackground)
+        color("surface", colorScheme.surface)
+        color("onSurface", colorScheme.onSurface)
+        color("surfaceVariant", colorScheme.surfaceVariant)
+        color("onSurfaceVariant", colorScheme.onSurfaceVariant)
+        color("surfaceTint", colorScheme.surfaceTint)
+        color("inverseSurface", colorScheme.inverseSurface)
+        color("inverseOnSurface", colorScheme.inverseOnSurface)
+        color("error", colorScheme.error)
+        color("onError", colorScheme.onError)
+        color("errorContainer", colorScheme.errorContainer)
+        color("onErrorContainer", colorScheme.onErrorContainer)
+        color("outline", colorScheme.outline)
+        color("outlineVariant", colorScheme.outlineVariant)
+        color("scrim", colorScheme.scrim)
+        color("surfaceBright", colorScheme.surfaceBright)
+        color("surfaceDim", colorScheme.surfaceDim)
+        color("surfaceContainer", colorScheme.surfaceContainer)
+        color("surfaceContainerHigh", colorScheme.surfaceContainerHigh)
+        color("surfaceContainerHighest", colorScheme.surfaceContainerHighest)
+        color("surfaceContainerLow", colorScheme.surfaceContainerLow)
+        color("surfaceContainerLowest", colorScheme.surfaceContainerLowest, "")
+        append("\n}")
+    }
+
+    fun encodeTo(output: OutputStream) = output.bufferedWriter().use { writer ->
+        val content = buildString {
+            appendLine(colorScheme("lightColorScheme", light))
+            append("\n")
+            appendLine(colorScheme("darkColorScheme", dark))
+        }
+
+        writer.write(content)
+    }
+
+    companion object Default {
+        const val MIME_TYPE = "text/css"
+        const val FILE_NAME = "color.css"
+    }
+}

--- a/app/src/main/kotlin/dev/sanmer/color/picker/reflect/ColorPicker.kt
+++ b/app/src/main/kotlin/dev/sanmer/color/picker/reflect/ColorPicker.kt
@@ -1,0 +1,147 @@
+package dev.sanmer.color.picker.reflect
+
+import android.content.Intent
+import android.net.Uri
+import android.webkit.JavascriptInterface
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.dergoogler.mmrl.webui.interfaces.WXInterface
+import com.dergoogler.mmrl.webui.interfaces.WXOptions
+import dev.sanmer.color.picker.model.ColorCss
+import dev.sanmer.color.picker.model.ColorJson
+import dev.sanmer.color.picker.model.ColorKt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class ColorPicker(wxOptions: WXOptions) : WXInterface(wxOptions) {
+    override var name: String = "ColorPicker"
+
+    private val dynamicLightColorScheme get() = dynamicLightColorScheme(context)
+    private val dynamicDarkColorScheme get() = dynamicDarkColorScheme(context)
+
+    private var lightColorScheme by mutableStateOf(dynamicLightColorScheme)
+    private var darkColorScheme by mutableStateOf(dynamicDarkColorScheme)
+
+    @JavascriptInterface
+    fun reload() {
+        lightColorScheme = dynamicLightColorScheme
+        darkColorScheme = dynamicDarkColorScheme
+    }
+
+    private fun exportToJson(uri: Uri) {
+        scope.launch(Dispatchers.IO) {
+            runCatching {
+                val colorJson = ColorJson(
+                    light = lightColorScheme,
+                    dark = darkColorScheme
+                )
+
+                checkNotNull(context.contentResolver.openOutputStream(uri)).use(
+                    colorJson::encodeTo
+                )
+            }.onFailure {
+                Timber.e(it)
+                console.error(it)
+            }
+        }
+    }
+
+    private fun exportToKotlin(uri: Uri) {
+        scope.launch(Dispatchers.IO) {
+            runCatching {
+                val colorKt = ColorKt(
+                    light = lightColorScheme,
+                    dark = darkColorScheme
+                )
+
+                checkNotNull(context.contentResolver.openOutputStream(uri)).use(
+                    colorKt::encodeTo
+                )
+            }.onFailure {
+                Timber.e(it)
+                console.error(it)
+            }
+        }
+    }
+
+    private fun exportToCss(uri: Uri) {
+        scope.launch(Dispatchers.IO) {
+            runCatching {
+                val colorCss = ColorCss(
+                    light = lightColorScheme,
+                    dark = darkColorScheme
+                )
+
+                checkNotNull(context.contentResolver.openOutputStream(uri)).use(
+                    colorCss::encodeTo
+                )
+            }.onFailure {
+                Timber.e(it)
+                console.error(it)
+            }
+        }
+    }
+
+    private fun createDocument(type: Int, fileName: String, mimeType: String) {
+        scope.launch(Dispatchers.IO) {
+            val createFileIntent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+                addCategory(Intent.CATEGORY_OPENABLE)
+                setType(mimeType)
+                putExtra(Intent.EXTRA_TITLE, fileName)
+            }
+
+            withActivity {
+                startActivityForResult(createFileIntent, type)
+            }
+        }
+    }
+
+    @JavascriptInterface
+    fun exportToKotlin() {
+        createDocument(
+            type = RESULT_CODE_KOTLIN,
+            fileName = ColorKt.FILE_NAME,
+            mimeType = ColorKt.MIME_TYPE
+        )
+    }
+
+    @JavascriptInterface
+    fun exportToJson() {
+        createDocument(
+            type = RESULT_CODE_JSON,
+            fileName = ColorJson.FILE_NAME,
+            mimeType = ColorJson.MIME_TYPE
+        )
+    }
+
+    @JavascriptInterface
+    fun exportToCss() {
+        createDocument(
+            type = RESULT_CODE_CSS,
+            fileName = ColorCss.FILE_NAME,
+            mimeType = ColorCss.MIME_TYPE
+        )
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        val uri = data?.data ?: return
+
+        when (requestCode) {
+            RESULT_CODE_JSON -> exportToJson(uri)
+            RESULT_CODE_KOTLIN -> exportToKotlin(uri)
+            RESULT_CODE_CSS -> exportToCss(uri)
+        }
+    }
+
+    private companion object {
+        const val RESULT_CODE_JSON: Int = 10191514
+        const val RESULT_CODE_KOTLIN: Int = 111522914
+        const val RESULT_CODE_CSS: Int = 3001919
+    }
+}

--- a/app/src/main/kotlin/dev/sanmer/color/picker/ui/main/MainScreen.kt
+++ b/app/src/main/kotlin/dev/sanmer/color/picker/ui/main/MainScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import dev.sanmer.color.picker.Const
 import dev.sanmer.color.picker.R
+import dev.sanmer.color.picker.model.ColorCss
 import dev.sanmer.color.picker.model.ColorJson
 import dev.sanmer.color.picker.model.ColorKt
 import dev.sanmer.color.picker.model.ColorSchemeCompat
@@ -70,7 +71,8 @@ fun MainScreen(
             ButtonsItem(
                 importJson = viewModel::importFromJson,
                 exportJson = viewModel::exportToJson,
-                exportKotlin = viewModel::exportToKotlin
+                exportKotlin = viewModel::exportToKotlin,
+                exportCss = viewModel::exportToCss
             )
 
             ColorsItem(
@@ -110,7 +112,8 @@ fun MainScreen(
 private fun ButtonsItem(
     importJson: (Uri) -> Unit,
     exportJson: (Uri) -> Unit,
-    exportKotlin: (Uri) -> Unit
+    exportKotlin: (Uri) -> Unit,
+    exportCss: (Uri) -> Unit
 ) = OutlinedCard(
     shape = RoundedCornerShape(15.dp)
 ) {
@@ -127,6 +130,11 @@ private fun ButtonsItem(
     val exportKotlinLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.CreateDocument(ColorKt.MIME_TYPE),
         onResult = { uri -> if (uri != null) exportKotlin(uri) }
+    )
+
+    val exportCssLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument(ColorCss.MIME_TYPE),
+        onResult = { uri -> if (uri != null) exportCss(uri) }
     )
 
     FlowRow(
@@ -169,6 +177,20 @@ private fun ButtonsItem(
         ) {
             Icon(
                 painter = painterResource(id = R.drawable.brand_kotlin),
+                contentDescription = null,
+                modifier = Modifier.size(ButtonDefaults.IconSize)
+            )
+
+            Spacer(modifier = Modifier.width(ButtonDefaults.IconSpacing))
+
+            Text(text = stringResource(id = R.string.home_export))
+        }
+
+        FilledTonalButton(
+            onClick = { exportCssLauncher.launch(ColorCss.FILE_NAME) }
+        ) {
+            Icon(
+                painter = painterResource(id = R.drawable.css),
                 contentDescription = null,
                 modifier = Modifier.size(ButtonDefaults.IconSize)
             )

--- a/app/src/main/kotlin/dev/sanmer/color/picker/viewmodel/HomeViewModel.kt
+++ b/app/src/main/kotlin/dev/sanmer/color/picker/viewmodel/HomeViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.sanmer.color.picker.model.ColorCss
 import dev.sanmer.color.picker.model.ColorJson
 import dev.sanmer.color.picker.model.ColorKt
 import dev.sanmer.color.picker.model.ColorSchemeCompat
@@ -86,6 +87,23 @@ class HomeViewModel @Inject constructor(
 
                 checkNotNull(context.contentResolver.openOutputStream(uri)).use(
                     colorKt::encodeTo
+                )
+            }.onFailure {
+                Timber.e(it)
+            }
+        }
+    }
+
+    fun exportToCss(uri: Uri) {
+        viewModelScope.launch(Dispatchers.IO) {
+            runCatching {
+                val colorCss = ColorCss(
+                    light = lightColorScheme,
+                    dark = darkColorScheme
+                )
+
+                checkNotNull(context.contentResolver.openOutputStream(uri)).use(
+                    colorCss::encodeTo
                 )
             }.onFailure {
                 Timber.e(it)

--- a/app/src/main/res/drawable/css.xml
+++ b/app/src/main/res/drawable/css.xml
@@ -1,0 +1,41 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M14,3v4a1,1 0,0 0,1 1h4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5,12v-7a2,2 0,0 1,2 -2h7l5,5v4"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M8,16.5a1.5,1.5 0,0 0,-3 0v3a1.5,1.5 0,0 0,3 0"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M11,20.25c0,0.414 0.336,0.75 0.75,0.75h1.25a1,1 0,0 0,1 -1v-1a1,1 0,0 0,-1 -1h-1a1,1 0,0 1,-1 -1v-1a1,1 0,0 1,1 -1h1.25a0.75,0.75 0,0 1,0.75 0.75"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M17,20.25c0,0.414 0.336,0.75 0.75,0.75h1.25a1,1 0,0 0,1 -1v-1a1,1 0,0 0,-1 -1h-1a1,1 0,0 1,-1 -1v-1a1,1 0,0 1,1 -1h1.25a0.75,0.75 0,0 1,0.75 0.75"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ kotlinxCoroutines = "1.10.2"
 kotlinxSerialization = "1.9.0"
 ksp = "2.2.0-2.0.2"
 timber = "5.0.1"
+webuix = "72241a9df4"
 
 [libraries]
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
@@ -46,6 +47,7 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 squareup-kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+webui-x = { group = "com.github.MMRLApp.WebUI-X-Portable", name = "webui", version.ref = "webuix" }
 
 [plugins]
 self-application = { id = "self.application", version = "unspecified" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven("https://jitpack.io")
     }
 }
 


### PR DESCRIPTION
## Implementation

This Pull Request adds support to export the current color scheme as css.

This gives the ability with your app to module developers to call "ColorPicker" in JavaScript once your app have been added to `dexFiles` in `config.json`

```jsonc
{
  "dexFiles": [
    {
      "type": "apk",
      "path": "dev.sanmer.color.picker",
      "className": "dev.sanmer.color.picker.reflect.ColorPicker",
      // Only set cache to false when you're developing a new plugin
      "cache": false
    },
    {
      "path": "plugins/classes.dex",
      "className": "dev.mmrl.Module"
    }
  ]
}
```
> Don't forget to remove the comments

API

```ts
interface ColorPicker {
    reload(): void
    exportToKotlin(): void
    exportToJson(): void
    exportToCss(): void
}

export {}

declare global {

    interface Window {
        /**
         * ColorPicker can be undefined if an error occurs or the APK was not found
         */
        ColorPicker: ColorPicker | undefined
    }
}
```


## Issues

The `ColorPicker.exportToJson()` function throws an error when executed from JavaScript.

<img width="32%" src="https://github.com/user-attachments/assets/1c1154ec-91f3-4844-bc8d-b28a79ea8089" />
